### PR TITLE
Fix default button for create file & folder UI

### DIFF
--- a/usr/bin/xfce4-desktop-service
+++ b/usr/bin/xfce4-desktop-service
@@ -280,6 +280,7 @@ class naming_GUI(Gtk.Window):
         self.name.set_text(name)
         self.name.set_can_default(False)
         self.name.set_can_focus(True)
+        self.name.set_activates_default(True)
         self.grid.attach(self.name, 1, 2, 3, 1)
         self.name.grab_focus()
 
@@ -294,12 +295,11 @@ class naming_GUI(Gtk.Window):
         button2.set_can_default(False)
         self.grid.attach(button2, 1, 3, 1, 1)
 
-        button1.grab_default()
-
         self.set_name = None
 
-        print(button1.has_default())
-
+        self.set_default(button1)
+        # button1.grab_default() would be the preferred way to set default
+        # but that function does not seem to work properly at this time
 
     def done(self, button):
         """Return Data"""


### PR DESCRIPTION
Changed the function for setting a default button as the preferred method does not work.  Additionally, added the "activates_default" property to the entry widget.

Did not see a dev branch to pull this into.  Also, let me know if the other UIs need the same treatment.  The issue was specific to the file & folder UIs, but the "Choose preferred application" for file browsers also doesn't work, for example.